### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/examples/asyncio-ssh-python-embed.py
+++ b/examples/asyncio-ssh-python-embed.py
@@ -43,8 +43,8 @@ def main(port=8222):
     def create_server():
         return MySSHServer(lambda: environ)
 
-    print('Listening on :%i' % port)
-    print('To connect, do "ssh localhost -p %i"' % port)
+    print('Listening on :{0:d}'.format(port))
+    print('To connect, do "ssh localhost -p {0:d}"'.format(port))
 
     loop.run_until_complete(
         asyncssh.create_server(create_server, '', port,

--- a/examples/python-embed-with-custom-prompt.py
+++ b/examples/python-embed-with-custom-prompt.py
@@ -19,14 +19,14 @@ def configure(repl):
         def in_tokens(self, cli):
             return [
                 (Token.In, 'Input['),
-                (Token.In.Number, '%s' % repl.current_statement_index),
+                (Token.In.Number, '{0!s}'.format(repl.current_statement_index)),
                 (Token.In, '] >>: '),
             ]
 
         def out_tokens(self, cli):
             return [
                 (Token.Out, 'Result['),
-                (Token.Out.Number, '%s' % repl.current_statement_index),
+                (Token.Out.Number, '{0!s}'.format(repl.current_statement_index)),
                 (Token.Out, ']: '),
             ]
 

--- a/ptpython/history_browser.py
+++ b/ptpython/history_browser.py
@@ -113,7 +113,7 @@ def create_popup_window(title, body):
             Window(width=D.exact(1), height=D.exact(1),
                    content=FillControl(BORDER.TOP_LEFT, token=Token.Window.Border)),
             TokenListToolbar(
-                get_tokens=lambda cli: [(Token.Window.Title, ' %s ' % title)],
+                get_tokens=lambda cli: [(Token.Window.Title, ' {0!s} '.format(title))],
                 align_center=True,
                 default_char=Char(BORDER.HORIZONTAL, Token.Window.Border)),
             Window(width=D.exact(1), height=D.exact(1),
@@ -358,7 +358,7 @@ class HistoryMapping(object):
                 history_lines.append(line)
 
         if len(python_history) > HISTORY_COUNT:
-            history_lines[0] = '# *** History has been truncated to %s lines ***' % HISTORY_COUNT
+            history_lines[0] = '# *** History has been truncated to {0!s} lines ***'.format(HISTORY_COUNT)
 
         self.history_lines = history_lines
         self.concatenated_history = '\n'.join(history_lines)

--- a/ptpython/ipython.py
+++ b/ptpython/ipython.py
@@ -134,7 +134,7 @@ class MagicsCompleter(Completer):
 
         for m in sorted(self.magics_manager.magics['line']):
             if m.startswith(text):
-                yield Completion('%s' % m, -len(text))
+                yield Completion('{0!s}'.format(m), -len(text))
 
 
 class AliasCompleter(Completer):
@@ -148,7 +148,7 @@ class AliasCompleter(Completer):
 
         for a, cmd in sorted(aliases, key=lambda a: a[0]):
             if a.startswith(text):
-                yield Completion('%s' % a, -len(text),
+                yield Completion('{0!s}'.format(a), -len(text),
                                  display_meta=cmd)
 
 
@@ -235,8 +235,8 @@ def initialize_extensions(shell, extensions):
                 shell.extension_manager.load_extension(ext)
             except:
                 ipy_utils.warn.warn(
-                    "Error in loading extension: %s" % ext +
-                    "\nCheck your config files in %s" % ipy_utils.path.get_ipython_dir())
+                    "Error in loading extension: {0!s}".format(ext) +
+                    "\nCheck your config files in {0!s}".format(ipy_utils.path.get_ipython_dir()))
                 shell.showtraceback()
 
 

--- a/ptpython/layout.py
+++ b/ptpython/layout.py
@@ -65,7 +65,7 @@ def python_sidebar(python_input):
         def append_category(category):
             tokens.extend([
                 (T, '  '),
-                (T.Title, '   %-36s' % category.title),
+                (T.Title, '   {0:<36!s}'.format(category.title)),
                 (T, '\n'),
             ])
 
@@ -86,9 +86,9 @@ def python_sidebar(python_input):
             token = T.Selected if selected else T
 
             tokens.append((T, ' >' if selected else '  '))
-            tokens.append((token.Label, '%-24s' % label, select_item))
+            tokens.append((token.Label, '{0:<24!s}'.format(label), select_item))
             tokens.append((token.Status, ' ', select_item))
-            tokens.append((token.Status, '%s' % status, goto_next))
+            tokens.append((token.Status, '{0!s}'.format(status), goto_next))
 
             if selected:
                 tokens.append((Token.SetCursorPosition, ''))
@@ -102,7 +102,7 @@ def python_sidebar(python_input):
             append_category(category)
 
             for option in category.options:
-                append(i, option.title, '%s' % option.get_current_value())
+                append(i, option.title, '{0!s}'.format(option.get_current_value()))
                 i += 1
 
         tokens.pop()  # Remove last newline.
@@ -294,7 +294,7 @@ def status_bar(key_bindings_manager, python_input):
         append((TB, ' '))
 
         # Position in history.
-        append((TB, '%i/%i ' % (python_buffer.working_index + 1,
+        append((TB, '{0:d}/{1:d} '.format(python_buffer.working_index + 1,
                                 len(python_buffer._working_lines))))
 
         # Shortcuts.
@@ -386,7 +386,7 @@ def show_sidebar_button_info(python_input):
         (token.Key, '[F2]', toggle_sidebar),
         (token, ' Menu', toggle_sidebar),
         (token, ' - '),
-        (token.PythonVersion, '%s %i.%i.%i' % (platform.python_implementation(),
+        (token.PythonVersion, '{0!s} {1:d}.{2:d}.{3:d}'.format(platform.python_implementation(),
                                                version[0], version[1], version[2])),
         (token, ' '),
     ]
@@ -413,7 +413,7 @@ def exit_confirmation(python_input, token=Token.ExitConfirmation):
     def get_tokens(cli):
         # Show "Do you really want to exit?"
         return [
-            (token, '\n %s ([y]/n)' % python_input.exit_message),
+            (token, '\n {0!s} ([y]/n)'.format(python_input.exit_message)),
             (Token.SetCursorPosition, ''),
             (token, '  \n'),
         ]

--- a/ptpython/prompt_style.py
+++ b/ptpython/prompt_style.py
@@ -45,7 +45,7 @@ class IPythonPrompt(PromptStyle):
     def in_tokens(self, cli):
         return [
             (Token.In, 'In ['),
-            (Token.In.Number, '%s' % self.python_input.current_statement_index),
+            (Token.In.Number, '{0!s}'.format(self.python_input.current_statement_index)),
             (Token.In, ']: '),
         ]
 
@@ -57,7 +57,7 @@ class IPythonPrompt(PromptStyle):
     def out_tokens(self, cli):
         return [
             (Token.Out, 'Out['),
-            (Token.Out.Number, '%s' % self.python_input.current_statement_index),
+            (Token.Out.Number, '{0!s}'.format(self.python_input.current_statement_index)),
             (Token.Out, ']:'),
             (Token, ' '),
         ]

--- a/ptpython/repl.py
+++ b/ptpython/repl.py
@@ -110,19 +110,19 @@ class PythonRepl(PythonInput):
                 result = eval(code, self.get_globals(), self.get_locals())
 
                 locals = self.get_locals()
-                locals['_'] = locals['_%i' % self.current_statement_index] = result
+                locals['_'] = locals['_{0:d}'.format(self.current_statement_index)] = result
 
                 if result is not None:
                     out_tokens = self.get_output_prompt_tokens(cli)
 
                     try:
-                        result_str = '%r\n' % (result, )
+                        result_str = '{0!r}\n'.format(result )
                     except UnicodeDecodeError:
                         # In Python 2: `__repr__` should return a bytestring,
                         # so to put it in a unicode context could raise an
                         # exception that the 'ascii' codec can't decode certain
                         # characters. Decode as utf-8 in that case.
-                        result_str = '%s\n' % repr(result).decode('utf-8')
+                        result_str = '{0!s}\n'.format(repr(result).decode('utf-8'))
 
                     # Align every line to the first one.
                     line_sep = '\n' + ' ' * token_list_width(out_tokens)
@@ -165,7 +165,7 @@ class PythonRepl(PythonInput):
         tokens = _lex_python_traceback(tb)
         cli.print_tokens(tokens, style=style_from_pygments(DefaultStyle))
 
-        output.write('%s\n\n' % e)
+        output.write('{0!s}\n\n'.format(e))
         output.flush()
 
     @classmethod
@@ -218,7 +218,7 @@ def run_config(repl, config_file='~/.ptpython/config.py'):
 
     # Check whether this file exists.
     if not os.path.exists(config_file):
-        print('Impossible to read %r' % config_file)
+        print('Impossible to read {0!r}'.format(config_file))
         enter_to_continue()
         return
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:ptpython?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:ptpython?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
